### PR TITLE
Removed unnecessary NULL check

### DIFF
--- a/ht.c
+++ b/ht.c
@@ -43,9 +43,7 @@ ht* ht_create(void) {
 void ht_destroy(ht* table) {
     // First free allocated keys.
     for (size_t i = 0; i < table->capacity; i++) {
-        if (table->entries[i].key != NULL) {
-            free((void*)table->entries[i].key);
-        }
+        free((void*)table->entries[i].key);
     }
 
     // Then free entries array and table itself.


### PR DESCRIPTION
It is not necessary to check if a pointer is NULL before freeing it because the standard says that it is safe to free a NULL pointer. See §7.20.3.2 of [ISO/IEC 9899:TC2](https://www.open-std.org/JTC1/SC22/wg14/www/docs/n1124.pdf).