### PR TITLE
Fixed out of bounds read on perfget.c and perfset.c

### DIFF
--- a/samples/perfget.c
+++ b/samples/perfget.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
         exit_nomem();
     }
 
-    for (char* p = contents; *p; p++) {
+    for (char* p = contents; *p;) {
         // Skip whitespace.
         while (*p && *p <= ' ') {
             p++;
@@ -61,6 +61,7 @@ int main(int argc, char **argv) {
         }
         if (*p != 0) {
             *p = 0;
+            p++;
         }
 
         // Look up word.

--- a/samples/perfset.c
+++ b/samples/perfset.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
         exit_nomem();
     }
 
-    for (char* p = contents; *p; p++) {
+    for (char* p = contents; *p;) {
         // Skip whitespace.
         while (*p && *p <= ' ') {
             p++;
@@ -61,6 +61,7 @@ int main(int argc, char **argv) {
         }
         if (*p != 0) {
             *p = 0;
+            p++;
         }
 
         // Look up word.


### PR DESCRIPTION
This fixes the out of bounds access on perfget.c and perfset.c caused by incrementing the loop variable 'p' in the body of the for loop and also in the third clause of for statement, which caused an additional increment on the last iteration of the loop, for any given string, resulting in reading beyond the allocated memory.